### PR TITLE
Allow to supply external secret and skip Secret creation for the chart

### DIFF
--- a/charts/allure-testops/templates/_helpers.tpl
+++ b/charts/allure-testops/templates/_helpers.tpl
@@ -71,11 +71,29 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Create a default fully qualified postgresql name.
+Create a default fully qualified redis name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "allure-testops.redis.fullname" -}}
 {{- printf "%s-%s" .Release.Name "redis-master" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Determine a secret name, either external or managed by this chart
+*/}}
+{{- define "allure-testops.secret.name" -}}
+{{- if not .Values.externalSecrets.enabled }}
+  {{- $secret_name := include "allure-ee.fullname" . }}
+  {{- printf $secret_name }}
+{{- else }}
+  {{- if .Values.externalSecrets.name }}
+    {{- $secret_name := .Values.externalSecrets.name }}
+    {{- printf $secret_name }}
+  {{- else }}
+    {{- $secret_name := include "allure-ee.fullname" . }}
+    {{- printf $secret_name }}
+  {{- end }}
+{{- end }}
 {{- end -}}
 
 {{- define "imagePullSecret" }}

--- a/charts/allure-testops/templates/allure/gateway-dep.yaml
+++ b/charts/allure-testops/templates/allure/gateway-dep.yaml
@@ -60,7 +60,7 @@ spec:
         - name: {{ $name | quote }}
           value: {{ $value | quote }}
 {{- end }}
-{{- $secret_name := include "allure-ee.fullname" . }}
+{{- $secret_name := include "allure-testops.secret.name" . }}
 {{- if .Values.redis.sentinel.enabled }}
         - name: SPRING_REDIS_SENTINEL_NODES
           value: "{{ .Values.redis.sentinel.nodes }}"

--- a/charts/allure-testops/templates/allure/migration-job.yaml
+++ b/charts/allure-testops/templates/allure/migration-job.yaml
@@ -31,7 +31,7 @@ spec:
               value: http://{{ template "allure-testops.minio.fullname" . }}
             - name: MINIO_SERVER_PORT_NUMBER
               value: {{ .Values.minio.service.ports.api }}
-{{- $secret_name := include "allure-ee.fullname" . }}
+{{- $secret_name := include "allure-testops.secret.name" . }}
             - name: MINIO_SERVER_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/allure-testops/templates/allure/report-statefulset.yaml
+++ b/charts/allure-testops/templates/allure/report-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
         - name: http
           containerPort: 8081
         env:
-{{- $secret_name := include "allure-ee.fullname" . }}
+{{- $secret_name := include "allure-testops.secret.name" . }}
         - name: ALLURE_ENDPOINT
 {{- if .Values.network.tls.enabled }}
           value: "https://{{ .Values.host }}"

--- a/charts/allure-testops/templates/allure/uaa-dep.yaml
+++ b/charts/allure-testops/templates/allure/uaa-dep.yaml
@@ -60,7 +60,7 @@ spec:
         ports:
         - name: http
           containerPort: 8082
-{{- $secret_name := include "allure-ee.fullname" . }}
+{{- $secret_name := include "allure-testops.secret.name" . }}
         env:
         - name: ALLURE_ENDPOINT
 {{- if .Values.network.tls.enabled }}

--- a/charts/allure-testops/templates/infra/secret.yaml
+++ b/charts/allure-testops/templates/infra/secret.yaml
@@ -1,4 +1,4 @@
----
+{{- if not .Values.externalSecrets.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -46,3 +46,4 @@ data:
   clientSecret: {{ .Values.allure.auth.oidc.client.secret | b64enc | quote }}
   ldapUser: {{ .Values.allure.auth.ldap.auth.user | b64enc | quote }}
   ldapPass: {{ .Values.allure.auth.ldap.auth.pass | b64enc | quote }}
+{{- end -}}

--- a/charts/allure-testops/values.yaml
+++ b/charts/allure-testops/values.yaml
@@ -62,6 +62,15 @@ strategy:
   rollingUpdate:
     maxUnavailable: 0
 
+###
+# Skip Kubernetes secret creation. It is for cases when Secret is created and managed by external means, for example using external-secrets
+# Do not enable unless you know what you're doing.
+###
+externalSecrets:
+  enabled: true
+# Provide a custom name for externally-provided Secret
+#  name: ""
+
 network:
   # Nginx Ingress
   ingress:


### PR DESCRIPTION
The PR addresses situation when Secret object is managed by other means (for example, external-secrets syncs it from Vault). 
Simple parameter "externalSecrets.enabled" can be set to true (defaults to false), and in this case infra/secret.yaml would not be created at all. User is responsible for supplying Secret in this case. User can additionally supply "externalSecrets.name" to set desired Secret name, or can skip it and the helper func will invoke "allure-ee.fullname" func for Secret name.

"allure-testops.secret.name" helper func determines whether custom name for Secret should be used, or standard naming from "allure-ee.fullname" should be used instead.