### PR TITLE
Optional securityContext parameter

### DIFF
--- a/charts/allure-testops/templates/allure/gateway-dep.yaml
+++ b/charts/allure-testops/templates/allure/gateway-dep.yaml
@@ -46,8 +46,9 @@ spec:
       - name: {{ template "allure-testops.gateway.fullname" . }}
         image: "{{ .Values.registry.repo }}/{{ .Values.registry.name }}/{{ .Values.gateway.image }}:{{ .Values.version | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.registry.pullPolicy }}
-        securityContext:
-          runAsUser: {{ .Values.runAsUser }}
+        {{- if .Values.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.gateway.service.port }}

--- a/charts/allure-testops/templates/allure/report-statefulset.yaml
+++ b/charts/allure-testops/templates/allure/report-statefulset.yaml
@@ -61,8 +61,9 @@ spec:
       - name: {{ template "allure-testops.report.fullname" . }}
         image: "{{ .Values.registry.repo }}/{{ .Values.registry.name }}/{{ .Values.report.image }}:{{ .Values.version | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.registry.pullPolicy }}
-        securityContext:
-          runAsUser: {{ .Values.runAsUser }}
+        {{- if .Values.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 8081

--- a/charts/allure-testops/templates/allure/uaa-dep.yaml
+++ b/charts/allure-testops/templates/allure/uaa-dep.yaml
@@ -53,8 +53,9 @@ spec:
       - name: {{ template "allure-testops.uaa.fullname" . }}
         image: "{{ .Values.registry.repo }}/{{ .Values.registry.name }}/{{ .Values.uaa.image }}:{{ .Values.version | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.registry.pullPolicy }}
-        securityContext:
-          runAsUser: {{ .Values.runAsUser }}
+        {{- if .Values.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 8082

--- a/charts/allure-testops/values.yaml
+++ b/charts/allure-testops/values.yaml
@@ -9,7 +9,9 @@ password: admin
 
 ## Security Context
 ## 65534 started by a user with lowest privilegies
-runAsUser: 65534
+containerSecurityContext:
+  enabled: true
+  runAsUser: 65534
 
 ## your-domain.tld
 ## the real DNS name (FQDN) of the allure testops instance


### PR DESCRIPTION
Sometimes users should be able to turn the `securityContext` off.

For example, OKD uses Security Context Constraints with custom UID/GID ranges and adds it on its own:
```yaml
  securityContext:
    fsGroup: 1000920000
    seLinuxOptions:
      level: s0:c30,c25
```
in the resulting pod manifests for gateway, report and uaa components.

So, sometimes it is necessary to disable this option in helm chart values.