### PR TITLE
[feat] Optional image for initContainers

### DIFF
--- a/charts/allure-testops/templates/allure/report-statefulset.yaml
+++ b/charts/allure-testops/templates/allure/report-statefulset.yaml
@@ -45,14 +45,14 @@ spec:
 {{- if .Values.postgresql.enabled }}
       initContainers:
         - name: check-db-ready
-          image: postgres:9.6.5
+          image: "{{ .Values.initContainers.postgresql.image }}:{{ .Values.initContainers.postgresql.version }}"
           command: [ 'sh', '-c',
             'until pg_isready -h {{ template "allure-testops.postgresql.fullname" . }} -p 5432;
              do echo waiting for database; sleep 2; done;' ]
 {{- else }}
       initContainers:
         - name: check-db-ready
-          image: postgres:9.6.5
+          image: "{{ .Values.initContainers.postgresql.image }}:{{ .Values.initContainers.postgresql.version }}"
           command: [ 'sh', '-c',
             'until pg_isready -h {{ .Values.postgresql.external.reportHost }} -p {{ .Values.postgresql.external.reportPort }};
             do echo waiting for database; sleep 2; done;' ]

--- a/charts/allure-testops/templates/allure/uaa-dep.yaml
+++ b/charts/allure-testops/templates/allure/uaa-dep.yaml
@@ -44,7 +44,7 @@ spec:
 {{- if .Values.postgresql.enabled }}
       initContainers:
         - name: check-db-ready
-          image: postgres:9.6.5
+          image: "{{ .Values.initContainers.postgresql.image }}:{{ .Values.initContainers.postgresql.version }}"
           command: [ 'sh', '-c',
             'until pg_isready -h {{ template "allure-testops.postgresql.fullname" . }} -p 5432;
              do echo waiting for database; sleep 2; done;' ]

--- a/charts/allure-testops/values.yaml
+++ b/charts/allure-testops/values.yaml
@@ -38,6 +38,13 @@ registry:
     password: bar
 
 
+###
+## Settings for initContainers images
+###
+initContainers:
+  postgresql:
+    image: postgres
+    version: 9.6.5
 
 ###
 ## Strategy for updating Gateway & UAA components


### PR DESCRIPTION
Sometimes the `initContainer` image should be overriden - e.g. in air-gapped environments with private container registry.