### PR TITLE
add resources section for report and uaa initContainers

### DIFF
--- a/charts/allure-testops/templates/allure/report-statefulset.yaml
+++ b/charts/allure-testops/templates/allure/report-statefulset.yaml
@@ -48,6 +48,10 @@ spec:
       initContainers:
         - name: check-db-ready
           image: postgres:14
+{{- with .Values.postgresql.init.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
           command: [ 'sh', '-c',
             'until pg_isready -h {{ template "allure-testops.postgresql.fullname" . }} -p 5432;
              do echo waiting for database; sleep 2; done;' ]
@@ -55,6 +59,10 @@ spec:
       initContainers:
         - name: check-db-ready
           image: postgres:14
+{{- with .Values.postgresql.init.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
           command: [ 'sh', '-c',
             'until pg_isready -h {{ .Values.postgresql.external.reportHost }} -p {{ .Values.postgresql.external.reportPort }};
             do echo waiting for database; sleep 2; done;' ]

--- a/charts/allure-testops/templates/allure/uaa-dep.yaml
+++ b/charts/allure-testops/templates/allure/uaa-dep.yaml
@@ -47,6 +47,10 @@ spec:
       initContainers:
         - name: check-db-ready
           image: postgres:14
+{{- with .Values.postgresql.init.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
           command: [ 'sh', '-c',
             'until pg_isready -h {{ template "allure-testops.postgresql.fullname" . }} -p 5432;
              do echo waiting for database; sleep 2; done;' ]
@@ -54,6 +58,10 @@ spec:
       initContainers:
         - name: check-db-ready
           image: postgres:14
+{{- with .Values.postgresql.init.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
           command: [ 'sh', '-c',
             'until pg_isready -h {{ .Values.postgresql.external.uaaHost }} -p {{ .Values.postgresql.external.uaaPort }};
             do echo waiting for database; sleep 2; done;' ]

--- a/charts/allure-testops/values.yaml
+++ b/charts/allure-testops/values.yaml
@@ -174,6 +174,14 @@ postgresql:
           CREATE DATABASE report TEMPLATE template0 ENCODING 'utf8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';
   persistence:
     size: 20Gi
+  init:
+    resources:
+      limits:
+        cpu: 1
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
 
 # Local FS is NOT disabled for migration purpose. Please bear in mind that primary FS for allure is S3
 fs:


### PR DESCRIPTION
Sometimes admission controller doesn't allow to create containers with resources section undefined.
This code fixes this issue and sets reasonable default values for initContainers  