### PR TITLE
Quote env value SMTP.PORT

### DIFF
--- a/charts/allure-testops/templates/allure/uaa-dep.yaml
+++ b/charts/allure-testops/templates/allure/uaa-dep.yaml
@@ -257,7 +257,7 @@ spec:
         - name: SPRING_MAIL_HOST
           value: {{ .Values.smtp.host }}
         - name: SPRING_MAIL_PORT
-          value: {{ .Values.smtp.port }}
+          value: "{{ .Values.smtp.port }}"
         - name: SPRING_MAIL_USERNAME
           value: {{ .Values.smtp.username }}
         - name: SPRING_MAIL_FROM


### PR DESCRIPTION
Without quotes helm cannot install Deployment with error message:
```
Error
Deployment in version \"v1\" cannot be handled as a Deployment
v1.Deployment.Spec
v1.DeploymentSpec.Template
v1.PodTemplateSpec.Spec
v1.PodSpec.Containers
[]v1.Container
v1.Container.Env
[]v1.EnvVar
v1.EnvVar.Value
ReadString
expects \" or n, but found 2, error found in #10 byte of ...|,\"value\":25},{\"name\"|...
```