### PR TITLE
Update secret.yaml

### DIFF
--- a/charts/allure-testops/templates/infra/secret.yaml
+++ b/charts/allure-testops/templates/infra/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externalSecrets.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -54,4 +55,5 @@ data:
   ldapPass: {{ .Values.allure.auth.ldap.auth.pass | b64enc | quote }}
 {{- if .Values.licenseKey }}
   licenseKey: {{ .Values.licenseKey | b64enc | quote }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
fix skip secret when externalsecret is enabled.

The chart does not have ability to disable the secret creation even when it says to enable externalSecret in order to use one.
it creates a dummy Secret object by using default values set in values.yaml .
@cheshi-mantu 