### PR TITLE
Use JRE trust store to validate CA certificate

### DIFF
--- a/charts/allure-testops/templates/allure/report-statefulset.yaml
+++ b/charts/allure-testops/templates/allure/report-statefulset.yaml
@@ -124,8 +124,13 @@ spec:
               value: {{ template "renderJavaOpts" .Values.report.resources.limits.memory }}
             - name: SPRING_RABBITMQ_ADDRESSES
               value: {{ template "rabbitHost" . }}
+{{- if or (eq .Values.postgresql.external.sslMode "require") (eq .Values.postgresql.external.sslMode "verify-ca") (eq .Values.postgresql.external.sslMode "verify-full") }}
+            - name: SPRING_DATASOURCE_URL
+              value: "jdbc:postgresql://{{ template "reportDBHost" . }}:{{ template "reportDBPort" . }}/{{ template "reportDBName" . }}?sslmode={{ template "postgresSSL" . }}&sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory"
+{{- else }}
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://{{ template "reportDBHost" . }}:{{ template "reportDBPort" . }}/{{ template "reportDBName" . }}?sslmode={{ template "postgresSSL" . }}"
+{{- end }}
 {{- if eq .Values.fs.type "S3" }}
             - name: {{ .Values.build }}_BLOBSTORAGE_TYPE
               value: S3

--- a/charts/allure-testops/templates/allure/uaa-dep.yaml
+++ b/charts/allure-testops/templates/allure/uaa-dep.yaml
@@ -72,8 +72,13 @@ spec:
 {{- include "renderCrypto" . | indent 10 }}
             - name: JAVA_TOOL_OPTIONS
               value: {{ template "renderJavaOpts" .Values.uaa.resources.limits.memory }}
+{{- if or (eq .Values.postgresql.external.sslMode "require") (eq .Values.postgresql.external.sslMode "verify-ca") (eq .Values.postgresql.external.sslMode "verify-full") }}
+            - name: SPRING_DATASOURCE_URL
+              value: "jdbc:postgresql://{{ template "uaaDBHost" . }}:{{ template "uaaDBPort" . }}/{{ template "uaaDBName" . }}?sslmode={{ template "postgresSSL" . }}&sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory"
+{{- else }}
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://{{ template "uaaDBHost" . }}:{{ template "uaaDBPort" . }}/{{ template "uaaDBName" . }}?sslmode={{ template "postgresSSL" . }}"
+{{- end }}
 {{- if .Values.certificates.endpoints }}
             - name: TLS_ENDPOINTS
               value: "{{ .Values.certificates.endpoints }}"


### PR DESCRIPTION
If  `sslmode` is set to `verify-full` and a PostgreSQL server is configured with untrusted root certificate the exception will be thrown:

```
initialization.","logger_name":"com.zaxxer.hikari.pool.HikariPool","thread_name":"main","level":"ERROR","level_value":40000,"stack_trace":"org.postgresql.util.PSQLException: Could not open SSL root certificate file ?/.postgresql/root.crt.
at org.postgresql.ssl.LibPQFactory.<init>(LibPQFactory.java:151)
at org.postgresql.core.SocketFactoryFactory.getSslSocketFactory(SocketFactoryFactory.java:61)
at org.postgresql.ssl.MakeSSL.convert(MakeSSL.java:34)
at org.postgresql.core.v3.ConnectionFactoryImpl.enableSSL(ConnectionFactoryImpl.java:571)
at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:168)
at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:235)
at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:49)
at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:247)
at org.postgresql.Driver.makeConnection(Driver.java:434)
at org.postgresql.Driver.connect(Driver.java:291)
at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:138)
at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:359)
at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:201)
at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:470)
at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:561)
at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:100)
at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:112)
at liquibase.integration.spring.SpringLiquibase.afterPropertiesSet(SpringLiquibase.java:266)
.....
org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:147)
at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:731)
at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:408)
at org.springframework.boot.SpringApplication.run(SpringApplication.java:307)
at io.qameta.allure.uaa.UaaApplication.main(UaaApplication.java:83)\nCaused by: java.io.FileNotFoundException: ?/.postgresql/root.crt (No such file or directory)
at java.base/java.io.FileInputStream.open0(Native Method)
at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
at java.base/java.io.FileInputStream.<init>(FileInputStream.java:111)
at org.postgresql.ssl.LibPQFactory.<init>(LibPQFactory.java:148)
```

Fix:
[The default SSL Socket factory is the LibPQFactory](https://jdbc.postgresql.org/documentation/ssl/) and the root certificate can't be found at the `?/.postgresql/root.crt` path. During the execution `entrypoint.sh` script  the root certificate is imported as a trusted certificate and could be validate via [DefaultJavaSSLFactory](https://jdbc.postgresql.org/documentation/publicapi/org/postgresql/ssl/DefaultJavaSSLFactory.html) (Socket factory that uses Java's default truststore to validate server certificate.).
```
if [ -n "${TLS_DB_ENDPOINTS}" ]; then
  echo "TLS Database Certificates are going to be fetched"
  for e in $(echo "$TLS_DB_ENDPOINTS" | sed "s/,/ /g"); do
    openssl s_client -starttls postgres -connect "$e" -showcerts -verify 5 < /dev/null 2> /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; print}' > "/tmp/${e%%:*}".cer
  done
  echo "Following certificates are retrieved:"
  echo "If certificates file sizes are 0 this means something is wrong with connection"
  for cert in /tmp/*.cer; do
      keytool -alias "${cert%%.cer}" -import -keystore "${CERTS_STORE}" -file "$cert" -storepass changeit -noprompt
  done
fi
```

