### PR TITLE
Allow setting SMTP credentials via ExternalSecret

### DIFF
--- a/charts/allure-testops/templates/allure/uaa-dep.yaml
+++ b/charts/allure-testops/templates/allure/uaa-dep.yaml
@@ -199,11 +199,17 @@ spec:
             - name: SPRING_MAIL_PORT
               value: "{{ .Values.smtp.port }}"
             - name: SPRING_MAIL_USERNAME
-              value: {{ .Values.smtp.username }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secret_name }}
+                  key: "smtpUsername"
             - name: ALLURE_MAIL_FROM
               value: {{ .Values.smtp.from }}
             - name: SPRING_MAIL_PASSWORD
-              value: {{ .Values.smtp.password }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secret_name }}
+                  key: "smtpPassword"
             - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH
               value: {{ .Values.smtp.authEnabled | quote }}
             - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE

--- a/charts/allure-testops/templates/infra/secret.yaml
+++ b/charts/allure-testops/templates/infra/secret.yaml
@@ -62,4 +62,8 @@ data:
 {{- if .Values.licenseApiToken }}
   licenceApiToken: {{ .Values.licenseApiToken | b64enc | quote }}
 {{- end }}
+{{- if .Values.smtp.enabled }}
+  smtpUsername: {{ .Values.smtp.username | b64enc | quote }}
+  smtpPassword: {{ .Values.smtp.password | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/allure-testops/values.yaml
+++ b/charts/allure-testops/values.yaml
@@ -276,6 +276,7 @@ smtp:
   port: 465
   authEnabled: true
   from: noreply@example.com
+  # Username and password may be set via ExternalSecret as well
   username: sa-testops-smtp
   password: SuperSecret
   # https://en.wikipedia.org/wiki/Opportunistic_TLS


### PR DESCRIPTION
Don't force users to store SMTP credentials in a code, allow using ExternalSecret instead.