### PR TITLE
Added ALLURE_TASKEXECUTOR_COREPOOLSIZE

### DIFF
--- a/charts/allure-testops/templates/allure/report-statefulset.yaml
+++ b/charts/allure-testops/templates/allure/report-statefulset.yaml
@@ -179,6 +179,8 @@ spec:
               value: {{ .Values.report.uploads.parseConsumers | quote }}
             - name: ALLURE_UPLOAD_STORE_CONSUMERSPERQUEUE
               value: {{ .Values.report.uploads.storeConsumers | quote }}
+            - name: ALLURE_TASKEXECUTOR_COREPOOLSIZE
+              value: {{ .Values.report.taskExecutorCorePoolSize }}
 {{- if or (eq .Values.postgresql.external.sslMode "require") (eq .Values.postgresql.external.sslMode "verify-ca") (eq .Values.postgresql.external.sslMode "verify-full") }}
             - name: TLS_DB_ENDPOINTS
               value: "{{ .Values.postgresql.external.reportHost}}:{{ .Values.postgresql.external.reportPort }}"

--- a/charts/allure-testops/values.yaml
+++ b/charts/allure-testops/values.yaml
@@ -476,6 +476,7 @@ report:
   maxDBConn: 10
   maxConcurrency: 5
   maxS3Concurrency: 200
+  taskExecutorCorePoolSize: 200
   uploads:
     parseConsumers: 10
     storeConsumers: 2


### PR DESCRIPTION
Added new parameter ALLURE_TASKEXECUTOR_COREPOOLSIZE. This parameter is used to configure high-load instances.