### PR TITLE
Allow kms key id to be sourced and used

### DIFF
--- a/charts/allure-testops/Chart.yaml
+++ b/charts/allure-testops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: allure-testops
-version: 4.14.7
+version: 4.14.8
 appVersion: 4.22.0
 
 description: Allure TestOps

--- a/charts/allure-testops/templates/_helpers.tpl
+++ b/charts/allure-testops/templates/_helpers.tpl
@@ -223,6 +223,13 @@
 {{- else }}
     value: {{ .Values.fs.s3.region}}
 {{- end }}
+{{ if .Values.fs.s3.kms.enabled }}
+  - name: {{ .Values.build}}_ALLURE_BLOBSTORAGE_S3_KMSKEYID
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "allure-testops.secret.name" . }}
+        key: "s3KmsKeyId"
+{{- end}}
 {{- if and (not .Values.allure.manualConfig) (not .Values.aws.enabled) }}
   - name: {{ .Values.build }}_BLOBSTORAGE_S3_ACCESSKEY
     valueFrom:

--- a/charts/allure-testops/templates/infra/secret.yaml
+++ b/charts/allure-testops/templates/infra/secret.yaml
@@ -46,6 +46,9 @@ data:
   s3AccessKey: {{ .Values.fs.s3.accessKey | b64enc | quote }}
   s3SecretKey: {{ .Values.fs.s3.secretKey | b64enc | quote }}
 {{- end}}
+{{ if .Values.fs.s3.kms.enabled }}
+  s3KmsKeyId: {{ .Values.fs.s3.kms.kmsKeyId | b64enc | quote }}
+{{- end }}
   redisPass: {{ .Values.redis.auth.password | b64enc | quote }}
   clientId: {{ .Values.allure.auth.oidc.client.id | b64enc | quote }}
   clientSecret: {{ .Values.allure.auth.oidc.client.secret | b64enc | quote }}

--- a/charts/allure-testops/templates/infra/vault.yaml
+++ b/charts/allure-testops/templates/infra/vault.yaml
@@ -44,6 +44,13 @@ spec:
         - objectName: "s3SecretKey"
           key: "s3SecretKey"
 {{- end }}
+
+{{ if .Values.fs.s3.kms.enabled }}
+      - objectName: "s3KmsKeyId"
+        secretPath: "{{ .Values.vault.secretPath }}"
+        secretKey: "s3_kms_key_id"
+{{- end }}
+
         - objectName: "smtpUsername"
           key: "smtpUsername"
         - objectName: "smtpPassword"
@@ -134,6 +141,12 @@ spec:
       - objectName: "s3SecretKey"
         secretPath: "{{ .Values.vault.secretPath }}"
         secretKey: "s3_secret_key"
+{{- end }}
+
+{{ if .Values.fs.s3.kms.enabled }}
+      - objectName: "s3KmsKeyId"
+        secretPath: "{{ .Values.vault.secretPath }}"
+        secretKey: "s3_kms_key_id"
 {{- end }}
 
       - objectName: "smtpUsername"

--- a/charts/allure-testops/values.yaml
+++ b/charts/allure-testops/values.yaml
@@ -251,6 +251,10 @@ fs:
     # If you run Allure Testops in AWS EKS you don't need stating accessKey & secretKey
     accessKey: foo
     secretKey: bar
+    kms:
+      enabled: false
+      # If using Vault then this is ignored
+      kmsKeyId: 
   csiStorage:
     storageClass: ""
     existingVolumeName: ""


### PR DESCRIPTION
@cheshi-mantu @a-ryoo 

We discussed this at the end of last year. Using RBAC for S3 access did indeed work as was described, but only if the S3 bucket doesn't use KMS encryption. In order for us to use this chart instead of our custom version together with S3 RBAC, we need to be able to source KMS ID and pass it in as an environment variable - this is what we're currently doing running version 4.16.5. 

This isn't tested so it's worth a close look. 