### PR TITLE
Fix a config issue with taskExecutorCorePoolSize and maxDBConn

### DIFF
--- a/charts/allure-testops/values.yaml
+++ b/charts/allure-testops/values.yaml
@@ -514,10 +514,10 @@ report:
     ttlWidgetsTrStatisticTrend: 1h
     ttlWidgetsTcLastResult: 1h
   image: allure-report
-  maxDBConn: 10
+  maxDBConn: 50
   maxConcurrency: 5
   maxS3Concurrency: 200
-  taskExecutorCorePoolSize: 200
+  taskExecutorCorePoolSize: 10
   uploads:
     parseConsumers: 10
     storeConsumers: 2


### PR DESCRIPTION
Fix a config issue with taskExecutorCorePoolSize and maxDBConn for the report

https://github.com/qameta/allure-testops-deployment/issues/102

Fix #102